### PR TITLE
バグ修正: 時間範囲のイベントでも正しく処理できること

### DIFF
--- a/src/google_calendar/fetch_calendar_events.py
+++ b/src/google_calendar/fetch_calendar_events.py
@@ -54,8 +54,8 @@ def fetch_tomorrow_events():
     return [
         event["summary"]
         for event in events
-        if datetime.datetime.fromisoformat(event["start"].get("date")).date()
-        == tomorrow
+        if (start := event["start"].get("date") or event["start"].get("dateTime"))
+        and datetime.datetime.fromisoformat(start).date() == tomorrow
     ]
 
 


### PR DESCRIPTION
全日イベントではない時間範囲のイベントがあると以下のエラーが出てしまっていたため、対応するように修正した

```
TypeError: fromisoformat: argument must be str

at .fetch_tomorrow_events ( /workspace/src/google_calendar/fetch_calendar_events.py:57 )
at .main ( /workspace/main.py:12 )
at .view_func ( /layers/google.python.pip/pip/lib/python3.12/site-packages/functions_framework/__init__.py:142 )
at .wrapper ( /layers/google.python.pip/pip/lib/python3.12/site-packages/functions_framework/execution_id.py:157 )
at .dispatch_request ( /layers/google.python.pip/pip/lib/python3.12/site-packages/flask/app.py:865 )
at .full_dispatch_request ( /layers/google.python.pip/pip/lib/python3.12/site-packages/flask/app.py:880 )
at .full_dispatch_request ( /layers/google.python.pip/pip/lib/python3.12/site-packages/flask/app.py:882 )
at .wsgi_app ( /layers/google.python.pip/pip/lib/python3.12/site-packages/flask/app.py:1473 )
```